### PR TITLE
fixed typo and generic type parameter position to match original MediatR

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Inspired by https://github.com/jbogard/MediatR
 }
 
 /// Create a request handler 
-class AddRequestHandler extends IRequestHandler<int, AddRequest> {
+class AddRequestHandler extends IRequestHandler<AddRequest, int> {
   @override
   Future<int> call(AddRequest request) async {
     return request.i + 1;
@@ -26,12 +26,12 @@ class AddRequestHandler extends IRequestHandler<int, AddRequest> {
 /// Register the handler to the mediator instance ( commonly stored as a singleton )
  final mediator = Mediator(Pipeline());
 
- mediator.registerHandler<int, AddRequest, AddRequestHandler>(
+ mediator.registerHandler<AddRequest, int, AddRequestHandler>(
           () => AddRequestHandler(),
         );
 
-/// Send the request througt the mediator instance
-final added = await mediator.send<int, AddRequest>(
+/// Send the request through the mediator instance
+final added = await mediator.send<AddRequest, int>(
           AddRequest(2),
         );
 print(added); // prints 3
@@ -82,9 +82,9 @@ mediator.unsubscribe<MyEvent>(eventHandler);
  ## Adding a middleware for all requests
  
 ```dart
-class LoggingBehaviour extends IPipelineBehaviour {
+class LoggingBehavior extends IPipelineBehavior {
   @override
-  Future proccess(IRequest request, RequestHandlerDelegate next) {
+  Future process(IRequest request, RequestHandlerDelegate next) {
     print(request);
     return next(request);
   }
@@ -93,7 +93,7 @@ class LoggingBehaviour extends IPipelineBehaviour {
 final mediator = Mediator(
   Pipeline()
     ..addMiddleware(
-      LoggingBehaviour(),
+      LoggingBehavior(),
     ),
 );
 ```

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -127,7 +127,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -171,10 +171,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -185,6 +187,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -272,7 +275,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -349,7 +352,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -398,7 +401,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/add_item_command.dart
+++ b/example/lib/add_item_command.dart
@@ -25,7 +25,3 @@ class EmptyItemException implements Exception {
   @override
   String toString() => 'Cannot add empty item';
 }
-
-class EmptyItemFailure extends Failure {
-  EmptyItemFailure(super.message);
-}

--- a/example/lib/get_items_query.dart
+++ b/example/lib/get_items_query.dart
@@ -1,10 +1,11 @@
-import 'package:example/items_repository.dart';
 import 'package:mediatr/mediatr.dart';
+
+import 'items_repository.dart';
 
 class GetItemsQuery extends IQuery<List<String>> {}
 
 class GetItemsQueryHandler
-    extends IRequestHandler<List<String>, GetItemsQuery> {
+    extends IRequestHandler<GetItemsQuery, List<String>> {
   final ItemsRepository itemsRepository;
 
   GetItemsQueryHandler(this.itemsRepository);

--- a/example/lib/logging_behavior.dart
+++ b/example/lib/logging_behavior.dart
@@ -1,8 +1,8 @@
 import 'package:mediatr/mediatr.dart';
 
-class LoggingBehaviour extends IPipelineBehaviour {
+class LoggingBehavior extends IPipelineBehavior {
   @override
-  Future proccess(IRequest request, RequestHandlerDelegate next) {
+  Future process(IRequest request, RequestHandlerDelegate next) {
     print('new request send $request');
     return next(request);
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,38 +47,30 @@ class _MyHomePageState extends State<MyHomePage> {
       error = null;
     });
 
-    final addedOrFailure =
-        await mediator.send<void, AddItemCommand>(AddItemCommand(itemToAdd));
-    addedOrFailure.fold(
-      (left) {
-        print("Failed to add item");
+    try {
+      await mediator.send<AddItemCommand, void>(AddItemCommand(itemToAdd));
 
-        setState(() {
-          error = left.message;
-        });
-      },
-      (right) {
-        print("Item succesfully added");
-        _controller.clear();
-      },
-    );
+      _controller.clear();
+    } on EmptyItemException {
+      setState(() {
+        error = 'Cannot add empty item';
+      });
+    }
   }
 
   Future<void> getItems() async {
-    final itemsOrFailure =
-        await mediator.send<List<String>, GetItemsQuery>(GetItemsQuery());
-    itemsOrFailure.fold(
-      (left) {
-        print('Failed to get items');
-      },
-      (right) {
-        print('Got items');
+    try {
+      final result =
+          await mediator.send<GetItemsQuery, List<String>>(GetItemsQuery());
 
-        setState(() {
-          items = right;
-        });
-      },
-    );
+      setState(() {
+        items = result;
+      });
+    } on EmptyItemException {
+      setState(() {
+        error = 'Cannot get items';
+      });
+    }
   }
 
   @override
@@ -99,12 +91,12 @@ class _MyHomePageState extends State<MyHomePage> {
                   Flexible(
                     child: ElevatedButton(
                       onPressed: addItem,
-                      child: Text(
+                      child: const Text(
                         'AddItem',
                       ),
                     ),
                   ),
-                  SizedBox(
+                  const SizedBox(
                     width: 20,
                   ),
                   Flexible(
@@ -113,7 +105,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       onChanged: (val) {
                         print(val);
                       },
-                      decoration: InputDecoration(
+                      decoration: const InputDecoration(
                         border: OutlineInputBorder(),
                         hintText: 'Enter item',
                       ),
@@ -124,7 +116,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             ElevatedButton(
               onPressed: getItems,
-              child: Text(
+              child: const Text(
                 'GetItems',
               ),
             ),
@@ -132,7 +124,7 @@ class _MyHomePageState extends State<MyHomePage> {
               Center(
                 child: Text(
                   error!,
-                  style: TextStyle(
+                  style: const TextStyle(
                     color: Colors.red,
                   ),
                 ),
@@ -140,7 +132,7 @@ class _MyHomePageState extends State<MyHomePage> {
             Center(
               child: Text(
                 'Items',
-                style: Theme.of(context).textTheme.headline6,
+                style: Theme.of(context).textTheme.headlineMedium,
               ),
             ),
             Flexible(

--- a/example/lib/setup_mediator.dart
+++ b/example/lib/setup_mediator.dart
@@ -1,36 +1,27 @@
-import 'dart:async';
-
 import 'get_items_query.dart';
 import 'items_repository.dart';
 import 'package:mediatr/mediatr.dart';
 
 import 'add_item_command.dart';
-import 'logging_behaviour.dart';
+import 'logging_behavior.dart';
 
 Mediator setupMediator() {
   final repo = ItemsRepository();
 
-  final pipeline = Pipeline()..addMiddleware(LoggingBehaviour());
-  final mediator = Mediator(pipeline, errorHandler: _customErrorHandler);
+  final pipeline = Pipeline()..addMiddleware(LoggingBehavior());
+  final mediator = Mediator(pipeline);
 
-  mediator.registerHandler<void, AddItemCommand, AddItemCommandHandler>(
+  mediator.registerHandler<AddItemCommand, void, AddItemCommandHandler>(
     () => AddItemCommandHandler(
       repo,
     ),
   );
 
-  mediator.registerHandler<List<String>, GetItemsQuery, GetItemsQueryHandler>(
+  mediator.registerHandler<GetItemsQuery, List<String>, GetItemsQueryHandler>(
     () => GetItemsQueryHandler(
       repo,
     ),
   );
 
   return mediator;
-}
-
-FutureOr<Failure?> _customErrorHandler(Exception e) {
-  if (e is EmptyItemException) {
-    return EmptyItemFailure(e.toString());
-  }
-  return null;
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,65 +5,58 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.8.2"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.5"
-  either_dart:
-    dependency: transitive
-    description:
-      name: either_dart
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.4"
+    version: "1.0.6"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -73,56 +66,86 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.3"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.4"
+    version: "0.8.0"
   mediatr:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "0.0.13"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.11.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -132,50 +155,65 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.9"
+    version: "0.6.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  vm_service:
+    dependency: transitive
+    description:
+      name: vm_service
+      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      url: "https://pub.dev"
+    source: hosted
+    version: "13.0.0"
 sdks:
-  dart: ">=2.17.6 <3.0.0"
+  dart: ">=3.2.0-0 <4.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.6 <3.0.0"
+  sdk: ">=2.17.6 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/lib/mediatr.dart
+++ b/lib/mediatr.dart
@@ -15,7 +15,7 @@ export 'src/internals/i_query.dart';
 export 'src/internals/i_request.dart';
 export 'src/internals/i_request_handler.dart';
 export 'src/internals/pipeline.dart';
-export 'src/behaviours/i_pipeline_behaviour.dart';
+export 'src/behaviors/i_pipeline_behavior.dart';
 
 typedef HandlerCreator<T> = T Function();
 typedef FuncEventHandler<T extends IDomainEvent> = FutureOr<void> Function(
@@ -25,7 +25,7 @@ typedef UnsubscribeFunc = void Function();
 
 /// Core mediator
 class Mediator {
-  /// Add pipeline behaviours that will be called with each request send through
+  /// Add pipeline behaviors that will be called with each request send through
   /// the mediator instance.
   final Pipeline pipeline;
 
@@ -83,7 +83,7 @@ class Mediator {
   }
 
   /// Sends a request to the given handlers after passing it through all middleware.
-  Future<R> send<R extends Object?, T extends IRequest<R>>(
+  Future<R> send<T extends IRequest<R>, R extends Object?>(
     T request,
   ) async {
     final handler = _getRequestHandlerFor<T>();
@@ -98,8 +98,8 @@ class Mediator {
   /// [R] is the return type of the request handler
   /// [IR] is the [IRequest] type
   /// [H] is the type of the [IRequestHandler], the return type of the [creator]
-  void registerHandler<R, IR extends IRequest<R>,
-      H extends IRequestHandler<R, IR>>(HandlerCreator<H> creator) {
+  void registerHandler<IR extends IRequest<R>, R,
+      H extends IRequestHandler<IR, R>>(HandlerCreator<H> creator) {
     handlers[IR] = creator;
   }
 

--- a/lib/src/behaviors/i_pipeline_behavior.dart
+++ b/lib/src/behaviors/i_pipeline_behavior.dart
@@ -1,0 +1,7 @@
+import '../internals/i_request.dart';
+
+typedef RequestHandlerDelegate<T> = Future<T> Function(IRequest<T> req);
+
+abstract class IPipelineBehavior<R extends IRequest, T> {
+  Future<T> process(R request, RequestHandlerDelegate next);
+}

--- a/lib/src/behaviours/i_pipeline_behaviour.dart
+++ b/lib/src/behaviours/i_pipeline_behaviour.dart
@@ -1,7 +1,0 @@
-import '../internals/i_request.dart';
-
-typedef RequestHandlerDelegate<T> = Future<T> Function(IRequest<T> req);
-
-abstract class IPipelineBehaviour<R extends IRequest, T> {
-  Future<T> proccess(R request, RequestHandlerDelegate next);
-}

--- a/lib/src/internals/i_command_handler.dart
+++ b/lib/src/internals/i_command_handler.dart
@@ -4,6 +4,6 @@ import 'i_request_handler.dart';
 
 /// Extend this class when you need to handle an [ICommand] that returns nothing.
 abstract class ICommandHandler<R extends IRequest<void>>
-    extends IRequestHandler<void, R> {
+    extends IRequestHandler<R, void> {
   const ICommandHandler();
 }

--- a/lib/src/internals/i_domain_event.dart
+++ b/lib/src/internals/i_domain_event.dart
@@ -1,4 +1,4 @@
-/// Subsclasses of IDomainEvent can be published through the mediator instane.
+/// Subclasses of IDomainEvent can be published through the mediator instance.
 abstract class IDomainEvent extends Object {
   /// Should be unique across events.
   String get name;

--- a/lib/src/internals/i_request_handler.dart
+++ b/lib/src/internals/i_request_handler.dart
@@ -2,7 +2,7 @@ import 'i_request.dart';
 
 /// Extend [IRequestHandler] with [R] as the return type
 /// and [T] as the [IRequest] you want to handle.
-abstract class IRequestHandler<R, T extends IRequest<R>> {
+abstract class IRequestHandler<T extends IRequest<R>, R> {
   const IRequestHandler();
 
   Future<R> call(T request);

--- a/lib/src/internals/pipeline.dart
+++ b/lib/src/internals/pipeline.dart
@@ -1,17 +1,16 @@
-import '../behaviours/i_pipeline_behaviour.dart';
+import '../behaviors/i_pipeline_behavior.dart';
 import 'i_request.dart';
 import 'i_request_handler.dart';
 
 /// A pipeline passes  an [IRequest] through all of its [middlewares]
 /// before being send to the [IRequestHandler]
 class Pipeline {
-  late final List<IPipelineBehaviour> middlewares = [];
+  late final List<IPipelineBehavior> middlewares = [];
 
   /// Adds a middleware to the [Pipeline]
-  void addMiddleware(IPipelineBehaviour behaviour) =>
-      middlewares.add(behaviour);
+  void addMiddleware(IPipelineBehavior behavior) => middlewares.add(behavior);
 
-  /// The function that gets called from [Mediator] in order to pass the [IRequest] throught the middlewares
+  /// The function that gets called from [Mediator] in order to pass the [IRequest] thought the middlewares
   Future passThrough(
     IRequest request,
     IRequestHandler requestHandler,
@@ -21,7 +20,7 @@ class Pipeline {
         return requestHandler(request);
       }
       final m = middlewares[index];
-      return m.proccess(
+      return m.process(
         request,
         (req) async => runner(index + 1),
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,12 +4,12 @@ version: 0.2.0
 homepage: https://github.com/GeorgopoulosGiannis/dart_mediatr
 
 environment:
-  sdk: ">=2.17.5 <3.0.0"
+  sdk: ">=2.17.5 <4.0.0"
 
 dependencies:
 
 dev_dependencies:
   test: ^1.22.2
-  lints: ^2.0.1
-  mocktail: ^0.3.0
+  lints: ^3.0.0
+  mocktail: ^1.0.3
 

--- a/test/mediator_test.dart
+++ b/test/mediator_test.dart
@@ -33,7 +33,7 @@ class DemoRequest extends IRequest<bool> {
   DemoRequest(this.duration);
 }
 
-class DemoRequestHandler extends IRequestHandler<bool, DemoRequest> {
+class DemoRequestHandler extends IRequestHandler<DemoRequest, bool> {
   @override
   Future<bool> call(DemoRequest request) async {
     await Future.delayed(request.duration);
@@ -144,7 +144,7 @@ void main() {
         'Subscribe with class',
         () {
           test(
-            'Should not call irrellevant handlers',
+            'Should not call irrelevant handlers',
             () async {
               /// arrange
               bool called = false;
@@ -235,7 +235,7 @@ void main() {
       );
 
       group(
-        'Unsubsribe',
+        'Unsubscribe',
         () {
           test(
             'Should remove event handler',
@@ -289,16 +289,16 @@ void main() {
     'Send',
     () {
       test(
-        'Should pass through all of pipeline behaviours',
+        'Should pass through all of pipeline behaviors',
         () async {
           final handler = DemoRequestHandler();
-          mediator.registerHandler<bool, DemoRequest, DemoRequestHandler>(
+          mediator.registerHandler<DemoRequest, bool, DemoRequestHandler>(
             () => handler,
           );
           final request = DemoRequest(duration);
           when(() => mockPipeline.passThrough(request, handler))
               .thenAnswer((_) async => true);
-          await mediator.send<bool, DemoRequest>(request);
+          await mediator.send<DemoRequest, bool>(request);
 
           verify(() => mockPipeline.passThrough(request, handler)).called(1);
         },
@@ -313,7 +313,7 @@ class AddRequest extends IRequest<int> {
   AddRequest(this.i);
 }
 
-class AddRequestHandler extends IRequestHandler<int, AddRequest> {
+class AddRequestHandler extends IRequestHandler<AddRequest, int> {
   @override
   Future<int> call(AddRequest request) async {
     return request.i + 1;


### PR DESCRIPTION
The generic type parameter currently does not match the original .NET MediatR library implementation. Therefore long term users coming from that like me will have a hard time keep tracking different position of the same type parameter on different platform which causes confusion.

Like in .NET you have:
```
// Request
public class GetItem : IRequest<IList<Item>>{
}

// Handler
public class GetItemHandler : IRequestHandler<GetItem, IList<Item>>{
....
}
```

But here we have:
```
// Request 
class GetItem extends IRequest<List<Item>>{
}

// Handler 
class GetItemHandler extends IRequestHandler<List<Item>, GetItem>{
....
}
```

Minor thing but with major confusion.

Also the positioning of Request -> Response is more natural sounding than Response <- Request.